### PR TITLE
Fixed SyntaxWarning when comparing integer with "is" instead of == in translate function

### DIFF
--- a/ls_colors_generator.py
+++ b/ls_colors_generator.py
@@ -1237,7 +1237,7 @@ def translate(color_list):
     if type(v) is not str:
       if type(v[0]) is str:
         v[0] = ord(v[0])
-      if len(v) is  3:
+      if len(v) == 3:
         color = color_char(v[0], v[1], v[2])
       else:
         color = color_char(v[0], v[1])


### PR DESCRIPTION
This fixes an error in python 3.9.2:

```
/usr/bin/ls_colors_generator:1240: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(v) is 3:
```